### PR TITLE
Handle fqdns with trailing dots

### DIFF
--- a/octodns_lexicon.py
+++ b/octodns_lexicon.py
@@ -104,6 +104,18 @@ class LexiconProvider(BaseProvider):
             exists = True
             self.log.debug("provider listed {!s}".format(lexicon_record))
 
+            # harmonize record values here
+            if lexicon_record['type'] in ['CNAME', 'MX', 'NS']:
+                if not lexicon_record['content'][:-1] == '.':
+                    domain_part = shlex.split(lexicon_record['content'])[-1]
+                    if '.' in domain_part:
+                        lexicon_record['content'] += '.'
+                    else:
+                        lexicon_record['content'] += ".{}".format(zone.name)
+
+                    self.log.info("Harmonizing [%s] -> [%s]",
+                                  domain_part, lexicon_record['content'])
+
             loaded_types[lexicon_record["name"]][lexicon_record["type"]] \
                 .append(lexicon_record)
 

--- a/octodns_lexicon_test.py
+++ b/octodns_lexicon_test.py
@@ -152,10 +152,8 @@ class TestLexiconProvider(TestCase):
         self.assertEqual(zone.records, {expected_record},
                          "relative names from list are handled correctly")
 
-    @mock.patch('lexicon.providers.gandi.Provider')
-    def test_populate_non_fqdn_like_values(self, _):
-        # Given
-        lexicon_data = [{'type': 'NS',
+    @mock.patch('lexicon.providers.gandi.Provider.list_records',
+                return_value=iter([{'type': 'NS',
                          'name': 'subzone',
                          'ttl': 10800,
                          'content': 'subzone.example.com',
@@ -164,14 +162,13 @@ class TestLexiconProvider(TestCase):
                          'name': 'subzone',
                          'ttl': 10800,
                          'content': 'relative',
-                         'id': '@'}]
-
+                         'id': '@'}]))
+    @mock.patch('lexicon.providers.gandi.Provider.authenticate')
+    def test_populate_non_fqdn_like_values(self, *_):
+        # Given
         provider = LexiconProvider(id="unittests",
                                    lexicon_config=lexicon_config)
         zone = Zone("blodapels.in.", [])
-
-        provider.lexicon_client.provider.list_records.side_effect \
-            = lambda *s: iter(lexicon_data)
 
         wanted_record_values = {'subzone.example.com.',
                                 'relative.blodapels.in.'}


### PR DESCRIPTION
Assume that when a record value contains ".", that it is a fqdn with missing trailing
dot, rather than a relative domain, for that case it appends the zone.name.

fixes #3