### PR TITLE
Escape ';' in TXT records to complain with octodns

### DIFF
--- a/octodns_lexicon.py
+++ b/octodns_lexicon.py
@@ -5,6 +5,7 @@
 
 import logging
 import shlex
+import re
 from threading import Lock
 
 from collections import defaultdict, namedtuple
@@ -263,7 +264,7 @@ class LexiconProvider(BaseProvider):
         return {
             'ttl': lexicon_records[0]['ttl'],
             'type': _type,
-            'values': [r['content'] for r in lexicon_records]
+            'values': [re.sub(';', '\;', r['content']) for r in lexicon_records]
         }
 
     def _data_for_CAA(self, _type, lexicon_records):


### PR DESCRIPTION
I have tried to move records from Yandex DNS to Cloudflare and G-Core Labs and discovered what Octodns expects escaped TXT records (https://github.com/octodns/octodns/blob/master/octodns/record/__init__.py#L1414)