### PR TITLE
Apply the lenient configuration parameter when fetching remote records

### DIFF
--- a/octodns_lexicon.py
+++ b/octodns_lexicon.py
@@ -152,7 +152,7 @@ class LexiconProvider(BaseProvider):
                     else:
                         record_name = record_by_name
 
-                    record = Record.new(zone, record_name, data, source=self)
+                    record = Record.new(zone, record_name, data, source=self, lenient=lenient)
 
                     # Some lexicon operations, specifically 'update',
                     # requires the 'identifier' to be used.


### PR DESCRIPTION
The `lenient` parameter, when configured at zone-level, isn't applied when populating `Records` from the remote zone, which can lead to errors preventing the sync. This patch aims to correct that behavior.